### PR TITLE
Transition deployment to Linux-based service

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Publish API
       if: ${{ github.event.release.prerelease == false }} 
-      run: dotnet publish "TransactionProcessorACL\TransactionProcessorACL.csproj" --configuration Release --output publishOutput -r win-x64 --self-contained
+      run: dotnet publish "TransactionProcessorACL\TransactionProcessorACL.csproj" --configuration Release --output publishOutput -r linux-x64 --self-contained
 
 
     - name: Build Release Package
@@ -73,7 +73,7 @@ jobs:
         dotnet nuget push Nugets/TransactionProcessorACL.DataTransferObjects.${{ steps.get_version.outputs.VERSION }}.nupkg --api-key ${{ secrets.PRIVATEFEED_APIKEY }} --source ${{ secrets.PRIVATEFEED_URL }} --skip-duplicate
 
   deploystaging:
-    runs-on: stagingserver
+    runs-on: [stagingserver, linux]
     needs: buildlinux
     environment: staging
     name: "Deploy to Staging"
@@ -83,30 +83,76 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: transactionprocessoracl
-
-      - name: Remove existing  Windows service
+          path: /tmp/transactionprocessoracl # Download to a temporary directory
+  
+      - name: Remove existing service (if applicable)
         run: |
-          $serviceName = "Transaction Processing - Transaction Processor ACL"
-          # Check if the service exists
-          if (Get-Service -Name $serviceName -ErrorAction SilentlyContinue) {
-            Stop-Service -Name $serviceName
-            sc.exe delete $serviceName
-          }
-
+          SERVICE_NAME="transactionprocessoracl"
+          if systemctl is-active --quiet "$SERVICE_NAME"; then
+            echo "Stopping existing service..."
+            sudo systemctl stop "$SERVICE_NAME"
+          fi
+          if systemctl is-enabled --quiet "$SERVICE_NAME"; then
+            echo "Disabling existing service..."
+            sudo systemctl disable "$SERVICE_NAME"
+          fi
+          if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+            echo "Removing existing service unit file..."
+            sudo rm "/etc/systemd/system/${SERVICE_NAME}.service"
+            sudo systemctl daemon-reload
+          fi
+  
       - name: Unzip the files
         run: |
-          Expand-Archive -Path transactionprocessoracl.zip -DestinationPath "C:\txnproc\transactionprocessing\transactionprocessoracl" -Force
-      
-      - name: Install as a Windows service
+          sudo mkdir -p /opt/txnproc/transactionprocessing/transactionprocessoracl
+          sudo unzip -o /tmp/transactionprocessoracl/transactionprocessoracl.zip -d /opt/txnproc/transactionprocessing/transactionprocessoracl
+  
+      # IMPORTANT: Add a step to ensure the .NET runtime is installed on the server
+      # This assumes it's not already there. If your base image already has it, you can skip this.
+      - name: Install .NET Runtime
         run: |
-          $serviceName = "Transaction Processing - Transaction Processor ACL"
-          $servicePath = "C:\txnproc\transactionprocessing\transactionprocessoracl\TransactionProcessorACL.exe"
-                   
-          New-Service -Name $serviceName -BinaryPathName $servicePath -Description "Transaction Processing - Transaction Processor ACL" -DisplayName "Transaction Processing - Transaction Processor ACL" -StartupType Automatic
-          Start-Service -Name $serviceName
+          # Example for Ubuntu. Adjust based on your .NET version (e.g., 8.0, 7.0)
+          # and if you need the SDK or just the runtime.
+          # This uses Microsoft's package repository for the latest versions.
+          wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt update
+          sudo apt install -y aspnetcore-runtime-9.0
+  
+      - name: Install and Start as a Linux service
+        run: |
+          SERVICE_NAME="transactionprocessoracl"
+          # The WorkingDirectory is crucial for .NET apps to find appsettings.json and other files
+          WORKING_DIRECTORY="/opt/txnproc/transactionprocessing/transactionprocessoracl"
+          DLL_NAME="TransactionProcessorACL.dll" # Your application's DLL
+          SERVICE_DESCRIPTION="Transaction Processing - Transaction Processor ACL"
+  
+          # Create a systemd service file
+          echo "[Unit]" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Description=${SERVICE_DESCRIPTION}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "After=network.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Service]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          # IMPORTANT: Use 'dotnet' to run your DLL
+          echo "ExecStart=/usr/bin/dotnet ${WORKING_DIRECTORY}/${DLL_NAME}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WorkingDirectory=${WORKING_DIRECTORY}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Restart=always" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "User=youruser"   # IMPORTANT: Change to a dedicated, less privileged user
+          echo "Group=yourgroup" # IMPORTANT: Change to a dedicated, less privileged group
+          echo "Environment=ASPNETCORE_ENVIRONMENT=Production" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service # Example
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Install]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WantedBy=multi-user.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+  
+          # Reload systemd, enable, and start the service
+          sudo systemctl daemon-reload
+          sudo systemctl enable "$SERVICE_NAME"
+          sudo systemctl start "$SERVICE_NAME"
+          sudo systemctl status "$SERVICE_NAME" --no-pager # For debugging/verification
 
   deployproduction:
-    runs-on: productionserver
+    runs-on: [productionserver, linux]
     needs: [buildlinux, deploystaging]
     environment: production
     name: "Deploy to Production"
@@ -116,24 +162,70 @@ jobs:
         uses: actions/download-artifact@v4.1.8
         with:
           name: transactionprocessoracl
-
-      - name: Remove existing  Windows service
+          path: /tmp/transactionprocessoracl # Download to a temporary directory
+  
+      - name: Remove existing service (if applicable)
         run: |
-          $serviceName = "Transaction Processing - Transaction Processor ACL"
-          # Check if the service exists
-          if (Get-Service -Name $serviceName -ErrorAction SilentlyContinue) {
-            Stop-Service -Name $serviceName
-            sc.exe delete $serviceName
-          }
-
+          SERVICE_NAME="transactionprocessoracl"
+          if systemctl is-active --quiet "$SERVICE_NAME"; then
+            echo "Stopping existing service..."
+            sudo systemctl stop "$SERVICE_NAME"
+          fi
+          if systemctl is-enabled --quiet "$SERVICE_NAME"; then
+            echo "Disabling existing service..."
+            sudo systemctl disable "$SERVICE_NAME"
+          fi
+          if [ -f "/etc/systemd/system/${SERVICE_NAME}.service" ]; then
+            echo "Removing existing service unit file..."
+            sudo rm "/etc/systemd/system/${SERVICE_NAME}.service"
+            sudo systemctl daemon-reload
+          fi
+  
       - name: Unzip the files
         run: |
-          Expand-Archive -Path transactionprocessoracl.zip -DestinationPath "C:\txnproc\transactionprocessing\transactionprocessoracl" -Force
-      
-      - name: Install as a Windows service
+          sudo mkdir -p /opt/txnproc/transactionprocessing/transactionprocessoracl
+          sudo unzip -o /tmp/transactionprocessoracl/transactionprocessoracl.zip -d /opt/txnproc/transactionprocessing/transactionprocessoracl
+  
+      # IMPORTANT: Add a step to ensure the .NET runtime is installed on the server
+      # This assumes it's not already there. If your base image already has it, you can skip this.
+      - name: Install .NET Runtime
         run: |
-          $serviceName = "Transaction Processing - Transaction Processor ACL"
-          $servicePath = "C:\txnproc\transactionprocessing\transactionprocessoracl\TransactionProcessorACL.exe"
-                   
-          New-Service -Name $serviceName -BinaryPathName $servicePath -Description "Transaction Processing - Transaction Processor ACL" -DisplayName "Transaction Processing - Transaction Processor ACL" -StartupType Automatic
-          Start-Service -Name $serviceName
+          # Example for Ubuntu. Adjust based on your .NET version (e.g., 8.0, 7.0)
+          # and if you need the SDK or just the runtime.
+          # This uses Microsoft's package repository for the latest versions.
+          wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt update
+          sudo apt install -y aspnetcore-runtime-9.0
+  
+      - name: Install and Start as a Linux service
+        run: |
+          SERVICE_NAME="transactionprocessoracl"
+          # The WorkingDirectory is crucial for .NET apps to find appsettings.json and other files
+          WORKING_DIRECTORY="/opt/txnproc/transactionprocessing/transactionprocessoracl"
+          DLL_NAME="TransactionProcessorACL.dll" # Your application's DLL
+          SERVICE_DESCRIPTION="Transaction Processing - Transaction Processor ACL"
+  
+          # Create a systemd service file
+          echo "[Unit]" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Description=${SERVICE_DESCRIPTION}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "After=network.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Service]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          # IMPORTANT: Use 'dotnet' to run your DLL
+          echo "ExecStart=/usr/bin/dotnet ${WORKING_DIRECTORY}/${DLL_NAME}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WorkingDirectory=${WORKING_DIRECTORY}" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "Restart=always" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "User=youruser"   # IMPORTANT: Change to a dedicated, less privileged user
+          echo "Group=yourgroup" # IMPORTANT: Change to a dedicated, less privileged group
+          echo "Environment=ASPNETCORE_ENVIRONMENT=Production" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service # Example
+          echo "" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "[Install]" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+          echo "WantedBy=multi-user.target" | sudo tee -a /etc/systemd/system/${SERVICE_NAME}.service
+  
+          # Reload systemd, enable, and start the service
+          sudo systemctl daemon-reload
+          sudo systemctl enable "$SERVICE_NAME"
+          sudo systemctl start "$SERVICE_NAME"
+          sudo systemctl status "$SERVICE_NAME" --no-pager # For debugging/verification


### PR DESCRIPTION
Updated `createrelease.yml` to shift from a Windows-based service to a Linux-based service. Key changes include:
- Targeting `linux-x64` in the `dotnet publish` command.
- Replacing PowerShell commands with `systemctl` for service management.
- Adding a step to install the .NET runtime on the Linux server.
- Adapting the service installation process to create a systemd service file.
- Modifying the overall deployment structure for Linux compatibility.

closes #335 