### PR TITLE
Introduce VersionCheckMiddleware and update dependencies

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -25,17 +25,34 @@ jobs:
     - name: Run Unit Tests
       run: |
         echo "ASPNETCORE_ENVIRONMENT are > ${ASPNETCORE_ENVIRONMENT}"
-        dotnet test "TransactionProcessorACL.Tests\TransactionProcessorACL.Tests.csproj"
-        dotnet test "TransactionProcessorACL.BusinessLogic.Tests\TransactionProcessorACL.BusinessLogic.Tests.csproj"
+        dotnet test "TransactionProcessorACL.Tests\TransactionProcessorACL.Tests.csproj" --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=acl-test-results.trx"
+        dotnet test "TransactionProcessorACL.BusinessLogic.Tests\TransactionProcessorACL.BusinessLogic.Tests.csproj" --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=bl-test-results.trx"
 
     - name: Build Docker Image
       run: docker build . --file TransactionProcessorACL/Dockerfile --tag transactionprocessoracl:latest
 
     - name: Run Integration Tests
-      run: dotnet test "TransactionProcessorACL.IntegrationTests\TransactionProcessorACL.IntegrationTests.csproj" --filter Category=PRTest
+      run: dotnet test "TransactionProcessorACL.IntegrationTests\TransactionProcessorACL.IntegrationTests.csproj" --filter Category=PRTest  --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
     - uses: actions/upload-artifact@v4.4.0
       if: ${{ failure() }}
       with:
         name: tracelogs
         path: /home/txnproc/trace/   
+
+    - name: Publish test results
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+          name: Unit Test Results
+          path: '**/TestResults/*.trx'
+          reporter: dotnet-trx
+          fail-on-error: true
+    
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+          retention-days: 30

--- a/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACL.BusinessLogic.Tests.csproj
+++ b/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACL.BusinessLogic.Tests.csproj
@@ -7,21 +7,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
     <PackageReference Include="Lamar" Version="15.0.1" />
     <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2025.12.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.12.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj
+++ b/TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="SecurityService.Client" Version="2025.12.2" />
-    <PackageReference Include="Shared" Version="2025.12.2" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2025.12.1" />
+    <PackageReference Include="Shared" Version="2026.2.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessorACL.IntegrationTests/TransactionProcessorACL.IntegrationTests.csproj
+++ b/TransactionProcessorACL.IntegrationTests/TransactionProcessorACL.IntegrationTests.csproj
@@ -7,26 +7,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
     <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2025.12.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.0" />
-	  <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-    <PackageReference Include="Reqnroll" Version="3.3.0" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.0" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
+	  <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="Reqnroll" Version="3.3.3" />
+    <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
 	<PackageReference Include="SecurityService.Client" Version="2025.12.2" />
 	<PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2025.12.2" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2025.12.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2025.12.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.12.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
     
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessorACL.Testing/TransactionProcessorACL.Testing.csproj
+++ b/TransactionProcessorACL.Testing/TransactionProcessorACL.Testing.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2025.12.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.12.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessorACL.Tests/General/VersionCheckMiddlewareTests.cs
+++ b/TransactionProcessorACL.Tests/General/VersionCheckMiddlewareTests.cs
@@ -1,0 +1,117 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Shouldly;
+using SimpleResults;
+using TransactionProcessorACL.BusinessLogic.Requests;
+using TransactionProcessorACL.Middleware;
+using Xunit;
+
+namespace TransactionProcessorACL.Tests.General
+{
+    public class VersionCheckMiddlewareTests
+    {
+        [Fact]
+        public async Task InvokeAsync_WhenMediatorReturnsSuccess_CallsNextAndLeavesStatusUnchanged()
+        {
+            // Arrange
+            var json = "{\"application_version\":\"1.2.3\"}";
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/api/transactions";
+            context.Request.ContentType = "application/json";
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            context.Request.ContentLength = context.Request.Body.Length;
+
+            bool nextCalled = false;
+            RequestDelegate next = ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            };
+
+            var mediatorMock = new Mock<IMediator>(MockBehavior.Strict);
+            mediatorMock
+                .Setup(m => m.Send(It.IsAny<VersionCheckCommands.VersionCheckCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Success);
+
+            var middleware = new VersionCheckMiddleware(next);
+
+            // Act
+            await middleware.InvokeAsync(context, mediatorMock.Object);
+
+            // Assert
+            nextCalled.ShouldBeTrue();
+            context.Response.StatusCode.ShouldBe(200);
+            mediatorMock.Verify(m => m.Send(It.IsAny<VersionCheckCommands.VersionCheckCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_WhenMediatorReturnsFailure_SetsStatus505AndDoesNotCallNext()
+        {
+            // Arrange
+            var json = "{\"application_version\":\"1.2.3\"}";
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/api/transactions";
+            context.Request.ContentType = "application/json";
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            context.Request.ContentLength = context.Request.Body.Length;
+
+            bool nextCalled = false;
+            RequestDelegate next = ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            };
+
+            var mediatorMock = new Mock<IMediator>(MockBehavior.Strict);
+            mediatorMock
+                .Setup(m => m.Send(It.IsAny<VersionCheckCommands.VersionCheckCommand>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result.Failure); // simulate old/invalid version
+
+            var middleware = new VersionCheckMiddleware(next);
+
+            // Act
+            await middleware.InvokeAsync(context, mediatorMock.Object);
+
+            // Assert
+            nextCalled.ShouldBeFalse();
+            context.Response.StatusCode.ShouldBe(505);
+            mediatorMock.Verify(m => m.Send(It.IsAny<VersionCheckCommands.VersionCheckCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_WhenPathIsHealth_SkipsVersionCheckAndCallsNext()
+        {
+            // Arrange
+            var context = new DefaultHttpContext();
+            context.Request.Path = "/health/ready";
+
+            bool nextCalled = false;
+            RequestDelegate next = ctx =>
+            {
+                nextCalled = true;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            };
+
+            var mediatorMock = new Mock<IMediator>(MockBehavior.Strict);
+            // mediator should not be called for health paths
+
+            var middleware = new VersionCheckMiddleware(next);
+
+            // Act
+            await middleware.InvokeAsync(context, mediatorMock.Object);
+
+            // Assert
+            nextCalled.ShouldBeTrue();
+            context.Response.StatusCode.ShouldBe(200);
+            mediatorMock.Verify(m => m.Send(It.IsAny<VersionCheckCommands.VersionCheckCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}

--- a/TransactionProcessorACL.Tests/TransactionProcessorACL.Tests.csproj
+++ b/TransactionProcessorACL.Tests/TransactionProcessorACL.Tests.csproj
@@ -7,20 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2025.12.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2025.12.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.1.1" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.1.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessorACL/Common/VersionCheckMiddleware.cs
+++ b/TransactionProcessorACL/Common/VersionCheckMiddleware.cs
@@ -1,68 +1,71 @@
-﻿    using System.IO;
-    using System.Text;
-    using System.Text.Json;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using MediatR;
-    using Microsoft.AspNetCore.Http;
-    using SimpleResults;
-    using TransactionProcessorACL.BusinessLogic.Requests;
+﻿using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using SimpleResults;
+using TransactionProcessorACL.BusinessLogic.Requests;
 
-    namespace TransactionProcessorACL.Middleware;
+namespace TransactionProcessorACL.Middleware;
 
-    public sealed class VersionCheckMiddleware {
-        private readonly RequestDelegate _next;
+public sealed class VersionCheckMiddleware {
+    private readonly RequestDelegate _next;
 
-        public VersionCheckMiddleware(RequestDelegate next) {
-            _next = next;
-        }
-
-        public async Task InvokeAsync(HttpContext context,
-                                      IMediator mediator) {
-            var path = context.Request.Path;
-
-            if (path.StartsWithSegments("/health") || path.StartsWithSegments("/healthui")) {
-                await _next(context);
-                return;
-            }
-
-            context.Request.EnableBuffering();
-
-            string? applicationVersion = null;
-
-            if (context.Request.ContentType?.Contains("application/json") == true) {
-                using var reader = new StreamReader(context.Request.Body, encoding: Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
-
-                string body = await reader.ReadToEndAsync().ConfigureAwait(false);
-
-                // Reset the request body stream position so the endpoint can read it
-                context.Request.Body.Position = 0;
-
-                try {
-                    using var json = JsonDocument.Parse(body);
-                    if (json.RootElement.TryGetProperty("application_version", out JsonElement versionProp)) {
-                        applicationVersion = versionProp.GetString();
-                    }
-                }
-                catch {
-                    // Ignore JSON parse errors — allow request to continue
-                }
-            }
-
-            // Fallback to querystring if needed
-            if (string.IsNullOrEmpty(applicationVersion)) {
-                applicationVersion = context.Request.Query["applicationVersion"];
-            }
-
-            CancellationToken cancellationToken = context.RequestAborted;
-
-            VersionCheckCommands.VersionCheckCommand versionCheckCommand = new(applicationVersion);
-            Result versionCheckResult = await mediator.Send(versionCheckCommand, cancellationToken).ConfigureAwait(false);
-            if (versionCheckResult.IsFailed) {
-                context.Response.StatusCode = 505;
-                return; // stop the pipeline
-            }
-
-            await _next(context).ConfigureAwait(false);
-        }
+    public VersionCheckMiddleware(RequestDelegate next) {
+        _next = next;
     }
+
+    public async Task InvokeAsync(HttpContext context,
+                                  IMediator mediator) {
+        var path = context.Request.Path;
+
+        if (path.StartsWithSegments("/health") || path.StartsWithSegments("/healthui")) {
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        context.Request.EnableBuffering();
+
+        string? applicationVersion = await ExtractApplicationVersionAsync(context).ConfigureAwait(false);
+
+        CancellationToken cancellationToken = context.RequestAborted;
+
+        var versionCheckCommand = new VersionCheckCommands.VersionCheckCommand(applicationVersion);
+        Result versionCheckResult = await mediator.Send(versionCheckCommand, cancellationToken).ConfigureAwait(false);
+
+        if (versionCheckResult.IsFailed) {
+            context.Response.StatusCode = 505;
+            return; // stop the pipeline
+        }
+
+        await _next(context).ConfigureAwait(false);
+    }
+
+    private static async Task<string?> ExtractApplicationVersionAsync(HttpContext context) {
+        // Only read the body if it's JSON (optional safety check)
+        if (context.Request.ContentType?.Contains("application/json") == true) {
+            using var reader = new StreamReader(context.Request.Body, encoding: Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+
+            string body = await reader.ReadToEndAsync().ConfigureAwait(false);
+
+            // Reset the request body stream position so the endpoint can read it
+            context.Request.Body.Position = 0;
+
+            try {
+                using var json = JsonDocument.Parse(body);
+                if (json.RootElement.TryGetProperty("application_version", out JsonElement versionProp)) {
+                    return versionProp.GetString();
+                }
+            }
+            catch {
+                // Ignore JSON parse errors — allow request to continue
+            }
+        }
+
+        // Fallback to querystring if needed
+        var qs = context.Request.Query["applicationVersion"];
+        return string.IsNullOrEmpty(qs) ? null : qs.ToString();
+    }
+}

--- a/TransactionProcessorACL/Common/VersionCheckMiddleware.cs
+++ b/TransactionProcessorACL/Common/VersionCheckMiddleware.cs
@@ -1,0 +1,68 @@
+﻿    using System.IO;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using MediatR;
+    using Microsoft.AspNetCore.Http;
+    using SimpleResults;
+    using TransactionProcessorACL.BusinessLogic.Requests;
+
+    namespace TransactionProcessorACL.Middleware;
+
+    public sealed class VersionCheckMiddleware {
+        private readonly RequestDelegate _next;
+
+        public VersionCheckMiddleware(RequestDelegate next) {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context,
+                                      IMediator mediator) {
+            var path = context.Request.Path;
+
+            if (path.StartsWithSegments("/health") || path.StartsWithSegments("/healthui")) {
+                await _next(context);
+                return;
+            }
+
+            context.Request.EnableBuffering();
+
+            string? applicationVersion = null;
+
+            if (context.Request.ContentType?.Contains("application/json") == true) {
+                using var reader = new StreamReader(context.Request.Body, encoding: Encoding.UTF8, detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true);
+
+                string body = await reader.ReadToEndAsync().ConfigureAwait(false);
+
+                // Reset the request body stream position so the endpoint can read it
+                context.Request.Body.Position = 0;
+
+                try {
+                    using var json = JsonDocument.Parse(body);
+                    if (json.RootElement.TryGetProperty("application_version", out JsonElement versionProp)) {
+                        applicationVersion = versionProp.GetString();
+                    }
+                }
+                catch {
+                    // Ignore JSON parse errors — allow request to continue
+                }
+            }
+
+            // Fallback to querystring if needed
+            if (string.IsNullOrEmpty(applicationVersion)) {
+                applicationVersion = context.Request.Query["applicationVersion"];
+            }
+
+            CancellationToken cancellationToken = context.RequestAborted;
+
+            VersionCheckCommands.VersionCheckCommand versionCheckCommand = new(applicationVersion);
+            Result versionCheckResult = await mediator.Send(versionCheckCommand, cancellationToken).ConfigureAwait(false);
+            if (versionCheckResult.IsFailed) {
+                context.Response.StatusCode = 505;
+                return; // stop the pipeline
+            }
+
+            await _next(context).ConfigureAwait(false);
+        }
+    }

--- a/TransactionProcessorACL/TransactionProcessorACL.csproj
+++ b/TransactionProcessorACL/TransactionProcessorACL.csproj
@@ -11,31 +11,31 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2025.12.2" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="MediatR" Version="14.0.0" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.1" />
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.0" />
-    <PackageReference Include="Shared" Version="2025.12.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2025.12.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
+    <PackageReference Include="Shared" Version="2026.2.1" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.0" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
+	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replaces inline version check in Startup.cs with a dedicated VersionCheckMiddleware class for centralized request version validation. Adds unit tests for the middleware. Updates multiple .csproj files to use newer package versions for improved compatibility and maintenance.
closes #499 
closes #524 
closes #552 