### PR TITLE
Update NuGet package versions across all projects

### DIFF
--- a/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACL.BusinessLogic.Tests.csproj
+++ b/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACL.BusinessLogic.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Lamar" Version="15.0.1" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.2" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj
+++ b/TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+    <PackageReference Include="Shared" Version="2026.3.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessorACL.IntegrationTests/TransactionProcessorACL.IntegrationTests.csproj
+++ b/TransactionProcessorACL.IntegrationTests/TransactionProcessorACL.IntegrationTests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
@@ -19,12 +19,12 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Reqnroll" Version="3.3.3" />
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-	<PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-	<PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+	<PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+	<PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.3" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.2" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.2" />
     
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/TransactionProcessorACL.Testing/TransactionProcessorACL.Testing.csproj
+++ b/TransactionProcessorACL.Testing/TransactionProcessorACL.Testing.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.2" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessorACL.Tests/TransactionProcessorACL.Tests.csproj
+++ b/TransactionProcessorACL.Tests/TransactionProcessorACL.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.1" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.1" />
+    <PackageReference Include="TransactionProcessor.Client" Version="2026.2.2" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.2.2" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/TransactionProcessorACL/Startup.cs
+++ b/TransactionProcessorACL/Startup.cs
@@ -78,8 +78,7 @@ namespace TransactionProcessorACL
             
             Startup.Configuration.LogConfiguration(Logger.LogWarning);
             app.UseMiddleware<TenantMiddleware>();
-            app.AddRequestLogging();
-            app.AddResponseLogging();
+            app.AddRequestResponseLogging();
             app.AddExceptionHandler();
             app.UseMiddleware<VersionCheckMiddleware>();
 

--- a/TransactionProcessorACL/TransactionProcessorACL.csproj
+++ b/TransactionProcessorACL/TransactionProcessorACL.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
 	  <PackageReference Include="Lamar" Version="15.0.1" />
 	  <PackageReference Include="MediatR" Version="14.0.0" />
 	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
@@ -26,9 +26,9 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
+    <PackageReference Include="Shared" Version="2026.3.1" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.3.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />


### PR DESCRIPTION
Upgraded ClientProxyBase to 2026.3.1 and updated related dependencies (TransactionProcessor.Client, SecurityService.Client, Shared, etc.) to latest minor versions. Also bumped NLog.Extensions.Logging to 6.1.2 for bug fixes and compatibility.

closes #568 
closes #567 
closes #573 