### PR TITLE
Make Sentry options configurable via app settings

### DIFF
--- a/TransactionProcessorACL/Program.cs
+++ b/TransactionProcessorACL/Program.cs
@@ -95,7 +95,8 @@ namespace TransactionProcessorACL
                                                                      o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                                                                      o.SendDefaultPii = true;
                                                                      o.MaxRequestBodySize = RequestSize.Always;
-                                                                     o.CaptureBlockingCalls = true;
+                                                                     o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                                                                     o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
                                                                      o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                                                                  });
                                                              }


### PR DESCRIPTION
Allow CaptureBlockingCalls and IncludeActivityData Sentry options to be set from configuration using ConfigurationReader, defaulting to false if not specified. This enables more flexible control of Sentry behavior without code changes.

closes #623 