### PR TITLE
Refactor voucher methods to use Result<T> for responses

### DIFF
--- a/TransactionProcessorACL.BusinessLogic.Tests/MediatorTests.cs
+++ b/TransactionProcessorACL.BusinessLogic.Tests/MediatorTests.cs
@@ -128,20 +128,20 @@ namespace TransactionProcessorACL.BusinessLogic.Tests
                                                                                        Decimal transactionValue,
                                                                                        CancellationToken cancellationToken) => Result.Success(new ProcessReconciliationResponse());
 
-        public async Task<GetVoucherResponse> GetVoucher(Guid estateId,
-                                                         Guid contractId,
-                                                         String voucherCode,
-                                                         CancellationToken cancellationToken)
+        public async Task<Result<GetVoucherResponse>> GetVoucher(Guid estateId,
+                                                                 Guid contractId,
+                                                                 String voucherCode,
+                                                                 CancellationToken cancellationToken)
         {
-            return new GetVoucherResponse();
+            return Result.Success(new GetVoucherResponse());
         }
 
-        public async Task<RedeemVoucherResponse> RedeemVoucher(Guid estateId,
-                                                               Guid contractId,
-                                                               String voucherCode,
+        public async Task<Result<RedeemVoucherResponse>> RedeemVoucher(Guid estateId,
+                                                                       Guid contractId,
+                                                                       String voucherCode,
                                                                CancellationToken cancellationToken)
         {
-            return new RedeemVoucherResponse();
+            return Result.Success(new RedeemVoucherResponse());
         }
 
         public async Task<Result<List<ContractResponse>>> GetMerchantContracts(Guid estateId,

--- a/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACLApplicationServiceTests.cs
+++ b/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACLApplicationServiceTests.cs
@@ -416,15 +416,16 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                 .ReturnsAsync(TestData.GetVoucherResponse);
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            GetVoucherResponse voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<GetVoucherResponse> voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.VoucherCode.ShouldBe(TestData.GetVoucherResponse.VoucherCode);
-            voucherResponse.ContractId.ShouldBe(TestData.ContractId);
-            voucherResponse.EstateId.ShouldBe(TestData.EstateId);
-            voucherResponse.ExpiryDate.ShouldBe(TestData.GetVoucherResponse.ExpiryDate);
-            voucherResponse.Value.ShouldBe(TestData.GetVoucherResponse.Value);
-            voucherResponse.VoucherId.ShouldBe(TestData.GetVoucherResponse.VoucherId);
+            voucherResponse.IsSuccess.ShouldBeTrue();
+            voucherResponse.Data.ShouldNotBeNull();
+            voucherResponse.Data.VoucherCode.ShouldBe(TestData.GetVoucherResponse.VoucherCode);
+            voucherResponse.Data.ContractId.ShouldBe(TestData.ContractId);
+            voucherResponse.Data.EstateId.ShouldBe(TestData.EstateId);
+            voucherResponse.Data.ExpiryDate.ShouldBe(TestData.GetVoucherResponse.ExpiryDate);
+            voucherResponse.Data.Value.ShouldBe(TestData.GetVoucherResponse.Value);
+            voucherResponse.Data.VoucherId.ShouldBe(TestData.GetVoucherResponse.VoucherId);
         }
 
         [Fact]
@@ -432,10 +433,9 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
         {
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
-            GetVoucherResponse voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<GetVoucherResponse> voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ResponseCode.ShouldBe("0004");
+            voucherResponse.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
@@ -445,10 +445,9 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                 .ReturnsAsync(Result.Failure());
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            GetVoucherResponse voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<GetVoucherResponse> voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ResponseCode.ShouldBe("0005");
+            voucherResponse.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
@@ -458,11 +457,9 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                                       .ThrowsAsync(new Exception("Error"));
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            GetVoucherResponse voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<GetVoucherResponse> voucherResponse = await applicationService.GetVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ResponseMessage.ShouldBe(TestData.VoucherExceptionResponseMessage);
-            voucherResponse.ResponseCode.ShouldBe(TestData.ExceptionErrorResponseCode);
+            voucherResponse.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
@@ -472,11 +469,11 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                                       .ReturnsAsync(Result.Success);
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            RedeemVoucherResponse voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<RedeemVoucherResponse> voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ContractId.ShouldBe(TestData.ContractId);
-            voucherResponse.EstateId.ShouldBe(TestData.EstateId);
+            voucherResponse.IsSuccess.ShouldBeTrue();
+            voucherResponse.Data.ContractId.ShouldBe(TestData.ContractId);
+            voucherResponse.Data.EstateId.ShouldBe(TestData.EstateId);
         }
 
         [Fact]
@@ -486,10 +483,9 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                 .ReturnsAsync(Result.Failure);
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
-            RedeemVoucherResponse voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<RedeemVoucherResponse> voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ResponseCode.ShouldBe("0004");
+            voucherResponse.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
@@ -499,10 +495,9 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                 .ReturnsAsync(Result.Failure());
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            RedeemVoucherResponse voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<RedeemVoucherResponse> voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ResponseCode.ShouldBe("0005");
+            voucherResponse.IsFailed.ShouldBeTrue();
         }
 
         [Fact]
@@ -513,11 +508,9 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
             
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            RedeemVoucherResponse voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
+            Result<RedeemVoucherResponse> voucherResponse = await applicationService.RedeemVoucher(TestData.EstateId, TestData.ContractId, TestData.VoucherCode, CancellationToken.None);
 
-            voucherResponse.ShouldNotBeNull();
-            voucherResponse.ResponseMessage.ShouldBe(TestData.RedeemVoucherExceptionResponseMessage);
-            voucherResponse.ResponseCode.ShouldBe(TestData.ExceptionErrorResponseCode);
+            voucherResponse.IsFailed.ShouldBeTrue();
         }
 
         [Theory]

--- a/TransactionProcessorACL.BusinessLogic/Services/ITransactionProcessorACLApplicationService.cs
+++ b/TransactionProcessorACL.BusinessLogic/Services/ITransactionProcessorACLApplicationService.cs
@@ -42,12 +42,12 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                                                                   Decimal transactionValue,
                                                                   CancellationToken cancellationToken);
 
-       Task<GetVoucherResponse> GetVoucher(Guid estateId,
+       Task<Result<GetVoucherResponse>> GetVoucher(Guid estateId,
                                            Guid contractId,
                                            String voucherCode,
                                            CancellationToken cancellationToken);
 
-       Task<RedeemVoucherResponse> RedeemVoucher(Guid estateId,
+       Task<Result<RedeemVoucherResponse>> RedeemVoucher(Guid estateId,
                                                  Guid contractId,
                                                  String voucherCode,
                                                  CancellationToken cancellationToken);

--- a/TransactionProcessorACL.BusinessLogic/Services/TransactionProcessorACLApplicationService.cs
+++ b/TransactionProcessorACL.BusinessLogic/Services/TransactionProcessorACLApplicationService.cs
@@ -76,11 +76,7 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                                                                                            String deviceIdentifier,
                                                                                            CancellationToken cancellationToken)
         {
-            // Get a client token to call the Transaction Processor
-            String clientId = ConfigurationReader.GetValue("AppSettings", "ClientId");
-            String clientSecret = ConfigurationReader.GetValue("AppSettings", "ClientSecret");
-
-            Result<TokenResponse> accessTokenResult = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
+            Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
             if (accessTokenResult.IsFailed) {
                 return ResultHelpers.CreateFailure(accessTokenResult);
             }
@@ -127,10 +123,10 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                                                                                          Dictionary<String, String> additionalRequestMetadata, CancellationToken cancellationToken)
         {
             Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
-            if (accessTokenResult.IsFailed)
-            {
+            if (accessTokenResult.IsFailed) {
                 return ResultHelpers.CreateFailure(accessTokenResult);
             }
+
             TokenResponse accessToken = accessTokenResult.Data;
 
             SaleTransactionRequest saleTransactionRequest = this.BuildSaleTransactionRequest(transactionNumber,
@@ -250,11 +246,7 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                                                                                        Decimal transactionValue,
                                                                                        CancellationToken cancellationToken)
         {
-            // Get a client token to call the Transaction Processor
-            String clientId = ConfigurationReader.GetValue("AppSettings", "ClientId");
-            String clientSecret = ConfigurationReader.GetValue("AppSettings", "ClientSecret");
-
-            Result<TokenResponse> accessTokenResult = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
+            Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
             if (accessTokenResult.IsFailed) {
                 return ResultHelpers.CreateFailure(accessTokenResult);
             }
@@ -281,110 +273,74 @@ namespace TransactionProcessorACL.BusinessLogic.Services
             }
         }
 
-        public async Task<GetVoucherResponse> GetVoucher(Guid estateId,
-                                                         Guid contractId,
-                                                         String voucherCode,
-                                                         CancellationToken cancellationToken)
+        public async Task<Result<GetVoucherResponse>> GetVoucher(Guid estateId,
+                                                                 Guid contractId,
+                                                                 String voucherCode,
+                                                                 CancellationToken cancellationToken)
         {
-            // Get a client token to call the Voucher Management
-            String clientId = ConfigurationReader.GetValue("AppSettings", "ClientId");
-            String clientSecret = ConfigurationReader.GetValue("AppSettings", "ClientSecret");
-
-            Result<TokenResponse> accessTokenResult = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
+            Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
             if (accessTokenResult.IsFailed) {
-                return CreateGetVoucherTokenErrorResponse();
+                return ResultHelpers.CreateFailure(accessTokenResult);
             }
 
             TokenResponse accessToken = accessTokenResult.Data;
 
-            try
-            {
+            try {
                 Result<TransactionProcessor.DataTransferObjects.GetVoucherResponse> getVoucherResult = await this.TransactionProcessorClient.GetVoucherByCode(accessToken.AccessToken, estateId, voucherCode, cancellationToken);
-                if (getVoucherResult.IsFailed)
-                {
-                    return CreateGetVoucherFailureResponse(getVoucherResult.Message);
+                if (getVoucherResult.IsFailed) {
+                    return ResultHelpers.CreateFailure(getVoucherResult);
                 }
 
-                return CreateGetVoucherSuccessResponse(estateId, contractId, getVoucherResult.Data);
+                return Result.Success(CreateGetVoucherSuccessResponse(estateId, contractId, getVoucherResult.Data));
             }
-            catch (Exception ex)
-            {
-                return CreateGetVoucherErrorResponse(ex);
+            catch (Exception ex) {
+                return Result.Failure(ex.GetExceptionMessages());
             }
         }
 
-        public async Task<RedeemVoucherResponse> RedeemVoucher(Guid estateId,
-                                                               Guid contractId,
-                                                               String voucherCode,
-                                                               CancellationToken cancellationToken)
+        public async Task<Result<RedeemVoucherResponse>> RedeemVoucher(Guid estateId,
+                                                                       Guid contractId,
+                                                                       String voucherCode,
+                                                                       CancellationToken cancellationToken)
         {
-            // Get a client token to call the Voucher Management
-            String clientId = ConfigurationReader.GetValue("AppSettings", "ClientId");
-            String clientSecret = ConfigurationReader.GetValue("AppSettings", "ClientSecret");
-
-            Result<TokenResponse> accessTokenResult = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
+            Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
             if (accessTokenResult.IsFailed) {
-                return new RedeemVoucherResponse {
-                    ResponseCode = "0004", // Token error
-                    ResponseMessage = "Token Error",
-                };
+                return ResultHelpers.CreateFailure(accessTokenResult);
             }
+            
             TokenResponse accessToken = accessTokenResult.Data;
 
-            RedeemVoucherResponse response;
-
-            try
-            {
-                RedeemVoucherRequest redeemVoucherRequest = new() {
-                    EstateId = estateId,
-                    VoucherCode = voucherCode
-                };
+            try {
+                RedeemVoucherRequest redeemVoucherRequest = new() { EstateId = estateId, VoucherCode = voucherCode };
 
                 Result redeemVoucherResponseResult = await this.TransactionProcessorClient.RedeemVoucher(accessToken.AccessToken, redeemVoucherRequest, cancellationToken);
 
-                if (redeemVoucherResponseResult.IsFailed)
-                {
-                    return new RedeemVoucherResponse
-                    {
-                        ResponseCode = "0005", // Voucher not found or already redeemed
-                        ResponseMessage = redeemVoucherResponseResult.Message,
-                    };
+                if (redeemVoucherResponseResult.IsFailed) {
+                    return ResultHelpers.CreateFailure(redeemVoucherResponseResult);
                 }
 
-                response = new RedeemVoucherResponse
-                {
+                return Result.Success(new RedeemVoucherResponse {
                     ResponseCode = "0000", // Success
                     ResponseMessage = "SUCCESS",
                     ContractId = contractId,
                     EstateId = estateId
-                };
+                });
             }
-            catch (Exception ex)
-            {
-                // This means there is an error in the request
-                response = new RedeemVoucherResponse
-                {
-                    ResponseCode = "0001", // Request Message error
-                    ResponseMessage = "Redeem Voucher Failed",
-                    ErrorMessages = ex.GetExceptionMessages()
-                };
+            catch (Exception ex) {
+                return Result.Failure(ex.GetExceptionMessages());
             }
-        
-            return response;
         }
 
         public async Task<Result<List<Models.ContractResponse>>> GetMerchantContracts(Guid estateId,
                                                                                       Guid merchantId,
                                                                                       CancellationToken cancellationToken) {
             Logger.LogInformation($"GetMerchantContracts: {estateId} {merchantId}");
-            // Get a client token to call the Transaction Processor
-            String clientId = ConfigurationReader.GetValue("AppSettings", "ClientId");
-            String clientSecret = ConfigurationReader.GetValue("AppSettings", "ClientSecret");
 
-            Result<TokenResponse> accessTokenResult = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
+            Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
             if (accessTokenResult.IsFailed) {
                 return ResultHelpers.CreateFailure(accessTokenResult);
             }
+
             TokenResponse accessToken = accessTokenResult.Data;
 
             Result<List<TransactionProcessor.DataTransferObjects.Responses.Contract.ContractResponse>> result = await this.TransactionProcessorClient.GetMerchantContracts(accessToken.AccessToken, estateId, merchantId, cancellationToken);
@@ -459,14 +415,11 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                                                                 Guid merchantId,
                                                                 CancellationToken cancellationToken) {
             Logger.LogWarning("in GetMerchant");
-            // Get a client token to call the Transaction Processor
-            String clientId = ConfigurationReader.GetValue("AppSettings", "ClientId");
-            String clientSecret = ConfigurationReader.GetValue("AppSettings", "ClientSecret");
-
-            Result<TokenResponse> accessTokenResult = await this.SecurityServiceClient.GetToken(clientId, clientSecret, cancellationToken);
+            Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
             if (accessTokenResult.IsFailed) {
                 return ResultHelpers.CreateFailure(accessTokenResult);
             }
+
             Logger.LogWarning("in GetMerchant - Got Token");
             TokenResponse accessToken = accessTokenResult.Data;
             
@@ -511,35 +464,7 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                 Balance = getVoucherResponse.Balance
             };
         }
-
-        private static GetVoucherResponse CreateGetVoucherFailureResponse(String responseMessage)
-        {
-            return new GetVoucherResponse
-            {
-                ResponseCode = "0005", // Voucher not found
-                ResponseMessage = responseMessage
-            };
-        }
-
-        private static GetVoucherResponse CreateGetVoucherTokenErrorResponse()
-        {
-            return new GetVoucherResponse
-            {
-                ResponseCode = "0004", // Token error
-                ResponseMessage = "Token Error",
-            };
-        }
-
-        private static GetVoucherResponse CreateGetVoucherErrorResponse(Exception ex)
-        {
-            return new GetVoucherResponse
-            {
-                ResponseCode = "0001", // Request Message error
-                ResponseMessage = "Get Voucher Failed",
-                ErrorMessages = ex.GetExceptionMessages()
-            };
-        }
-
+        
         private static ProcessReconciliationResponse CreateReconciliationErrorResponse(Guid estateId,
                                                                                        Guid merchantId,
                                                                                        Exception ex)
@@ -569,7 +494,7 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                 TransactionValue = transactionValue
             };
 
-            SerialisedMessage requestSerialisedMessage = new SerialisedMessage();
+            SerialisedMessage requestSerialisedMessage = new();
             requestSerialisedMessage.Metadata.Add(MetadataContants.KeyNameEstateId, estateId.ToString());
             requestSerialisedMessage.Metadata.Add(MetadataContants.KeyNameMerchantId, merchantId.ToString());
             requestSerialisedMessage.SerialisedData = JsonConvert.SerializeObject(reconciliationRequest,
@@ -625,7 +550,7 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                 TransactionType = "LOGON"
             };
 
-            SerialisedMessage requestSerialisedMessage = new SerialisedMessage();
+            SerialisedMessage requestSerialisedMessage = new();
             requestSerialisedMessage.Metadata.Add(MetadataContants.KeyNameEstateId, estateId.ToString());
             requestSerialisedMessage.Metadata.Add(MetadataContants.KeyNameMerchantId, merchantId.ToString());
             requestSerialisedMessage.SerialisedData = JsonConvert.SerializeObject(logonTransactionRequest,


### PR DESCRIPTION
Refactored GetVoucher and RedeemVoucher methods (and related interfaces/tests) to return Result<T> instead of direct DTOs, standardizing error handling and success/failure reporting. Updated tests to assert on Result<T> and removed redundant error response helpers. Improved consistency and clarity in service method responses.

closes #611 
closes #612 