### PR TITLE
Handle null input in ConvertFrom by returning empty list

### DIFF
--- a/TransactionProcessorACL.Tests/General/ModelFactoryTests.cs
+++ b/TransactionProcessorACL.Tests/General/ModelFactoryTests.cs
@@ -375,7 +375,7 @@ namespace TransactionProcessorACL.Tests.General
             List<Models.ContractResponse> model = null;
             List<DataTransferObjects.Responses.ContractResponse> dto = modelFactory.ConvertFrom(model);
 
-            dto.ShouldBeNull();
+            dto.Count.ShouldBe(0);
         }
 
         [Fact]

--- a/TransactionProcessorACL/Factories/ModelFactory.cs
+++ b/TransactionProcessorACL/Factories/ModelFactory.cs
@@ -182,12 +182,12 @@ namespace TransactionProcessorACL.Factories
 
         public List<DataTransferObjects.Responses.ContractResponse> ConvertFrom(List<Models.ContractResponse> model)
         {
+            List<DataTransferObjects.Responses.ContractResponse> responses = new();
+
             if (model == null)
             {
-                return null;
+                return responses;
             }
-
-            List<DataTransferObjects.Responses.ContractResponse> responses = new();
 
             foreach (Models.ContractResponse contractModel in model)
             {


### PR DESCRIPTION
Changed ConvertFrom to return an empty list instead of null when the input model is null, improving null safety and consistency. Moved responses list initialization before the null check to support this behavior.

closes #622 