### PR TITLE
Refactor ProcessSaleTransaction to use parameter tuples

### DIFF
--- a/TransactionProcessorACL.BusinessLogic.Tests/MediatorTests.cs
+++ b/TransactionProcessorACL.BusinessLogic.Tests/MediatorTests.cs
@@ -108,15 +108,12 @@ namespace TransactionProcessorACL.BusinessLogic.Tests
                                                                                            String deviceIdentifier,
                                                                                            CancellationToken cancellationToken) => Result.Success(new ProcessLogonTransactionResponse());
         
-        public async Task<Result<ProcessSaleTransactionResponse>> ProcessSaleTransaction(Guid estateId,
-                                                                                         Guid merchantId,
+        public async Task<Result<ProcessSaleTransactionResponse>> ProcessSaleTransaction((Guid estateId, Guid merchantId) merchantData,
                                                                                          DateTime transactionDateTime,
                                                                                          String transactionNumber,
                                                                                          String deviceIdentifier,
-                                                                                         Guid operatorId,
                                                                                          String customerEmailAddress,
-                                                                                         Guid contractId,
-                                                                                         Guid productId,
+                                                                                         (Guid operatorId, Guid contractId, Guid productId) productData,
                                                                                          Dictionary<String, String> additionalRequestMetadata,
                                                                                          CancellationToken cancellationToken) => Result.Success(new ProcessSaleTransactionResponse());
 

--- a/TransactionProcessorACL.BusinessLogic.Tests/RequestHandlerTests.cs
+++ b/TransactionProcessorACL.BusinessLogic.Tests/RequestHandlerTests.cs
@@ -72,15 +72,12 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
         {
             Mock<ITransactionProcessorACLApplicationService> applicationService = new Mock<ITransactionProcessorACLApplicationService>();
             applicationService
-                .Setup(a => a.ProcessSaleTransaction(It.IsAny<Guid>(),
-                                                      It.IsAny<Guid>(),
+                .Setup(a => a.ProcessSaleTransaction(It.IsAny<(Guid, Guid)>(),
                                                       It.IsAny<DateTime>(),
                                                       It.IsAny<String>(),
                                                       It.IsAny<String>(),
-                                                      It.IsAny<Guid>(),
                                                       It.IsAny<String>(),
-                                                      It.IsAny<Guid>(),
-                                                      It.IsAny<Guid>(),
+                                                      It.IsAny<(Guid, Guid, Guid)>(),
                                                       It.IsAny<Dictionary<String,String>>(),
                                                       It.IsAny<CancellationToken>())).ReturnsAsync(TestData.ProcessSaleTransactionResponse);
 

--- a/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACLApplicationServiceTests.cs
+++ b/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACLApplicationServiceTests.cs
@@ -165,15 +165,12 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                                       .ReturnsAsync(TestData.SerialisedMessageResponseSale);
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction(TestData.EstateId,
-                                                                                                             TestData.MerchantId,
-                                                                                                             TestData.TransactionDateTime,
+            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction((TestData.EstateId, TestData.MerchantId),
+            TestData.TransactionDateTime,
                                                                                                              TestData.TransactionNumber,
                                                                                                              TestData.DeviceIdentifier,
-                                                                                                             TestData.OperatorId,
                                                                                                              TestData.CustomerEmailAddress,
-                                                                                                             TestData.ContractId,
-                                                                                                             TestData.ProductId,
+                                                                                                             (TestData.OperatorId, TestData.ContractId, TestData.ProductId),
                                                                                                              TestData.AdditionalRequestMetadata,
                                                                                                              CancellationToken.None);
 
@@ -193,15 +190,12 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                                       .ReturnsAsync(TestData.SerialisedMessageResponseSale);
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction(TestData.EstateId,
-                                                                                                             TestData.MerchantId,
+            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction((TestData.EstateId, TestData.MerchantId),
                                                                                                              TestData.TransactionDateTime,
                                                                                                              TestData.TransactionNumber,
                                                                                                              TestData.DeviceIdentifier,
-                                                                                                             TestData.OperatorId,
                                                                                                              TestData.CustomerEmailAddress,
-                                                                                                             TestData.ContractId,
-                                                                                                             TestData.ProductId,
+                                                                                                             (TestData.OperatorId, TestData.ContractId, TestData.ProductId),
                                                                                                              TestData.AdditionalRequestMetadata,
                                                                                                              CancellationToken.None);
 
@@ -235,15 +229,12 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
         {
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Failure());
 
-            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction(TestData.EstateId,
-                                                                                                             TestData.MerchantId,
+            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction((TestData.EstateId, TestData.MerchantId),
                                                                                                              TestData.TransactionDateTime,
                                                                                                              TestData.TransactionNumber,
                                                                                                              TestData.DeviceIdentifier,
-                                                                                                             TestData.OperatorId,
                                                                                                              TestData.CustomerEmailAddress,
-                                                                                                             TestData.ContractId,
-                                                                                                             TestData.ProductId,
+                                                                                                             (TestData.OperatorId, TestData.ContractId, TestData.ProductId),
                                                                                                              TestData.AdditionalRequestMetadata,
                                                                                                              CancellationToken.None);
 
@@ -257,15 +248,12 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                                       .ReturnsAsync(Result.Failure());
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction(TestData.EstateId,
-                TestData.MerchantId,
+            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction((TestData.EstateId, TestData.MerchantId),
                 TestData.TransactionDateTime,
                 TestData.TransactionNumber,
                 TestData.DeviceIdentifier,
-                TestData.OperatorId,
                 TestData.CustomerEmailAddress,
-                TestData.ContractId,
-                TestData.ProductId,
+                (TestData.OperatorId, TestData.ContractId, TestData.ProductId),
                 TestData.AdditionalRequestMetadata,
                 CancellationToken.None);
 
@@ -279,15 +267,12 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
                                       .ThrowsAsync(new Exception("Error"));
             securityServiceClient.Setup(s => s.GetToken(It.IsAny<String>(), It.IsAny<String>(), It.IsAny<CancellationToken>())).ReturnsAsync(Result.Success(TestData.TokenResponse));
 
-            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction(TestData.EstateId,
-                                                                                                          TestData.MerchantId,
+            Result<ProcessSaleTransactionResponse> result = await applicationService.ProcessSaleTransaction((TestData.EstateId, TestData.MerchantId),
                                                                                                           TestData.TransactionDateTime,
                                                                                                           TestData.TransactionNumber,
                                                                                                           TestData.DeviceIdentifier,
-                                                                                                          TestData.OperatorId,
                                                                                                           TestData.CustomerEmailAddress,
-                                                                                                          TestData.ContractId,
-                                                                                                          TestData.ProductId,
+                                                                                                          (TestData.OperatorId, TestData.ContractId, TestData.ProductId),
                                                                                                           TestData.AdditionalRequestMetadata,
                                                                                                           CancellationToken.None);
             result.IsSuccess.ShouldBeTrue();

--- a/TransactionProcessorACL.BusinessLogic/RequestHandlers/ProcessLogonTransactionRequestHandler.cs
+++ b/TransactionProcessorACL.BusinessLogic/RequestHandlers/ProcessLogonTransactionRequestHandler.cs
@@ -64,15 +64,12 @@ namespace TransactionProcessorACL.BusinessLogic.RequestHandlers
         public async Task<Result<ProcessSaleTransactionResponse>> Handle(TransactionCommands.ProcessSaleTransactionCommand command,
                                                                          CancellationToken cancellationToken)
         {
-            return await this.ApplicationService.ProcessSaleTransaction(command.EstateId,
-                command.MerchantId,
+            return await this.ApplicationService.ProcessSaleTransaction((command.EstateId, command.MerchantId),
                 command.TransactionDateTime,
                 command.TransactionNumber,
                 command.DeviceIdentifier,
-                command.OperatorId,
                 command.CustomerEmailAddress,
-                command.ContractId,
-                command.ProductId,
+                (command.OperatorId, command.ContractId, command.ProductId),
                 command.AdditionalRequestMetadata,
                 cancellationToken);
         }

--- a/TransactionProcessorACL.BusinessLogic/Services/ITransactionProcessorACLApplicationService.cs
+++ b/TransactionProcessorACL.BusinessLogic/Services/ITransactionProcessorACLApplicationService.cs
@@ -22,17 +22,13 @@ namespace TransactionProcessorACL.BusinessLogic.Services
                                                                       String deviceIdentifier,
                                                                       CancellationToken cancellationToken);
         
-        Task<Result<ProcessSaleTransactionResponse>> ProcessSaleTransaction(Guid estateId,
-                                                                      Guid merchantId,
-                                                                      DateTime transactionDateTime,
-                                                                      String transactionNumber,
-                                                                      String deviceIdentifier,
-                                                                      Guid operatorId,
-                                                                      String customerEmailAddress,
-                                                                      Guid contractId,
-                                                                      Guid productId,
-                                                                      Dictionary<String,String> additionalRequestMetadata,
-                                                                      CancellationToken cancellationToken);
+        Task<Result<ProcessSaleTransactionResponse>> ProcessSaleTransaction((Guid estateId, Guid merchantId) merchantData,
+                                                                            DateTime transactionDateTime,
+                                                                            String transactionNumber,
+                                                                            String deviceIdentifier,
+                                                                            String customerEmailAddress,
+                                                                            (Guid operatorId, Guid contractId, Guid productId) productData,
+                                                                            Dictionary<String, String> additionalRequestMetadata, CancellationToken cancellationToken);
 
        Task<Result<ProcessReconciliationResponse>> ProcessReconciliation(Guid estateId,
                                                                   Guid merchantId,

--- a/TransactionProcessorACL.BusinessLogic/Services/TransactionProcessorACLApplicationService.cs
+++ b/TransactionProcessorACL.BusinessLogic/Services/TransactionProcessorACLApplicationService.cs
@@ -112,14 +112,12 @@ namespace TransactionProcessorACL.BusinessLogic.Services
         /// <param name="additionalRequestMetadata">The additional request metadata.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns></returns>
-        public async Task<Result<ProcessSaleTransactionResponse>> ProcessSaleTransaction(Guid estateId,
-                                                                                         Guid merchantId,
+        public async Task<Result<ProcessSaleTransactionResponse>> ProcessSaleTransaction((Guid estateId, Guid merchantId) merchantData,
                                                                                          DateTime transactionDateTime,
                                                                                          String transactionNumber,
                                                                                          String deviceIdentifier,
-                                                                                         Guid operatorId,
                                                                                          String customerEmailAddress,
-                                                                                         Guid contractId, Guid productId,
+                                                                                         (Guid operatorId, Guid contractId, Guid productId) productData,
                                                                                          Dictionary<String, String> additionalRequestMetadata, CancellationToken cancellationToken)
         {
             Result<TokenResponse> accessTokenResult = await this.GetAccessToken(cancellationToken);
@@ -132,13 +130,13 @@ namespace TransactionProcessorACL.BusinessLogic.Services
             SaleTransactionRequest saleTransactionRequest = this.BuildSaleTransactionRequest(transactionNumber,
                                                                                             deviceIdentifier,
                                                                                             transactionDateTime,
-                                                                                            operatorId,
+                                                                                            productData.operatorId,
                                                                                             customerEmailAddress,
-                                                                                            contractId,
-                                                                                            productId,
+                                                                                            productData.contractId,
+                                                                                            productData.productId,
                                                                                             additionalRequestMetadata);
             
-            SerialisedMessage requestSerialisedMessage = this.BuildSaleTransactionSerialisedMessage(estateId, merchantId, saleTransactionRequest);
+            SerialisedMessage requestSerialisedMessage = this.BuildSaleTransactionSerialisedMessage(merchantData.estateId, merchantData.merchantId, saleTransactionRequest);
 
             ProcessSaleTransactionResponse response = null;
 
@@ -152,11 +150,11 @@ namespace TransactionProcessorACL.BusinessLogic.Services
 
                 SaleTransactionResponse saleTransactionResponse = JsonConvert.DeserializeObject<SaleTransactionResponse>(responseSerialisedMessage.SerialisedData);
 
-                response = this.CreateSaleTransactionResponse(saleTransactionResponse, estateId, merchantId);
+                response = this.CreateSaleTransactionResponse(saleTransactionResponse, merchantData.estateId, merchantData.merchantId);
             }
             catch (Exception ex)
             {
-                response = this.CreateSaleTransactionErrorResponse(estateId, merchantId, ex);
+                response = this.CreateSaleTransactionErrorResponse(merchantData.estateId, merchantData.merchantId, ex);
             }
 
             return Result.Success(response);


### PR DESCRIPTION
Refactored the ProcessSaleTransaction method and related code to accept (estateId, merchantId) and (operatorId, contractId, productId) as tuples instead of separate parameters. Updated the interface, implementation, request handler, and all unit tests to use the new tuple-based signatures for improved clarity and maintainability.

closes #611 