### PR TITLE
Update CI workflows and Dockerfile for improved builds

### DIFF
--- a/.github/workflows/createrelease.yml
+++ b/.github/workflows/createrelease.yml
@@ -23,13 +23,7 @@ jobs:
       run: dotnet restore TransactionProcessorACL.sln --source ${{ secrets.PUBLICFEEDURL }} --source ${{ secrets.PRIVATEFEED_URL }}
 
     - name: Build Code
-      run: dotnet build TransactionProcessorACL.sln --configuration Release
-
-    - name: Run Unit Tests
-      run: |
-        echo "ASPNETCORE_ENVIRONMENT are > ${ASPNETCORE_ENVIRONMENT}"
-        dotnet test "TransactionProcessorACL.Tests\TransactionProcessorACL.Tests.csproj"      
-        dotnet test "TransactionProcessorACL.BusinessLogic.Tests\TransactionProcessorACL.BusinessLogic.Tests.csproj"      
+      run: dotnet build TransactionProcessorACL.sln --configuration Release     
             
     - name: Publish Images to Docker Hub - Pre Release
       if: ${{ github.event.release.prerelease == true }} 
@@ -52,7 +46,6 @@ jobs:
               -p:AssemblyVersion=${{ steps.get_version.outputs.VERSION }}
               -p:FileVersion=${{ steps.get_version.outputs.VERSION }}
               -p:InformationalVersion=${{ steps.get_version.outputs.VERSION }}
-
 
     - name: Build Release Package
       run: |

--- a/.github/workflows/nightlybuild.yml
+++ b/.github/workflows/nightlybuild.yml
@@ -46,6 +46,28 @@ jobs:
     - name: Run Integration Tests
       run: dotnet test "TransactionProcessorACL.IntegrationTests\TransactionProcessorACL.IntegrationTests.csproj"
 
+    - uses: actions/upload-artifact@v4.4.0
+      with:
+        name: tracelogs
+        path: /home/runner/trace/ 
+
+    - name: Publish test results
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+          name: Unit Test Results
+          path: '**/TestResults/*.trx'
+          reporter: dotnet-trx
+          fail-on-error: true
+    
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+          retention-days: 30
+
     - uses: dacbd/create-issue-action@main
       if: ${{ failure() }}
       name: Create an issue on build failure

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -35,10 +35,9 @@ jobs:
       run: dotnet test "TransactionProcessorACL.IntegrationTests\TransactionProcessorACL.IntegrationTests.csproj" --filter Category=PRTest  --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
     - uses: actions/upload-artifact@v4.4.0
-      if: ${{ failure() }}
       with:
         name: tracelogs
-        path: /home/txnproc/trace/   
+        path: /home/runner/trace/   
 
     - name: Publish test results
       uses: dorny/test-reporter@v1

--- a/TransactionProcessorACL/Dockerfile
+++ b/TransactionProcessorACL/Dockerfile
@@ -23,8 +23,5 @@ RUN dotnet publish "TransactionProcessorACL.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
-RUN groupadd --gid 10001 appuser \
-    && useradd --uid 10001 --gid appuser --shell /usr/sbin/nologin appuser
-COPY --from=publish --chown=appuser:appuser /app/publish .
-USER appuser
+COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "TransactionProcessorACL.dll"]


### PR DESCRIPTION
- Removed explicit unit test steps from createrelease.yml to streamline the build process.
- Added artifact upload and test reporting to nightlybuild.yml, with 30-day retention for test results.
- Fixed trace log path in pullrequest.yml to use /home/runner/trace/.
- Simplified Dockerfile by removing non-root user creation and ownership changes.
closes #653 