### PR TITLE
Centralize NuGet package versions and refactor MediatR setup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,56 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.6" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
+    <PackageVersion Include="EventStoreProjections" Version="2023.12.3" />
+    <PackageVersion Include="Lamar" Version="16.0.0" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageVersion Include="MessagingService.IntegrationTesting.Helpers" Version="2026.4.3-build126" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="7.5.0" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.4.3-build157" />
+    <PackageVersion Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
+    <PackageVersion Include="Shared" Version="2026.5.6" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.6" />
+    <PackageVersion Include="Shared.Results.Web" Version="2026.5.6" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+    <PackageVersion Include="TransactionProcessor.Client" Version="2026.4.3-build354" />
+    <PackageVersion Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build354" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACL.BusinessLogic.Tests.csproj
+++ b/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACL.BusinessLogic.Tests.csproj
@@ -7,21 +7,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Lamar" Version="15.0.1" />
-    <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build354" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build354" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Lamar" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+      <PackageReference Include="TransactionProcessor.Client" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj
+++ b/TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build354" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="TransactionProcessor.Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessorACL.IntegrationTests/TransactionProcessorACL.IntegrationTests.csproj
+++ b/TransactionProcessorACL.IntegrationTests/TransactionProcessorACL.IntegrationTests.csproj
@@ -7,26 +7,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="EventStoreProjections" Version="2023.12.3" />
-    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" Version="2026.4.3-build126" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
-	  <PackageReference Include="NUnit" Version="4.5.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Reqnroll" Version="3.3.3" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-	<PackageReference Include="SecurityService.Client" Version="2026.4.3-build157" />
-	<PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build157" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.6" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build354" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build354" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="EventStoreProjections" />
+    <PackageReference Include="MessagingService.IntegrationTesting.Helpers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+      <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Reqnroll.NUnit" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="TransactionProcessor.Client" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" />
     
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessorACL.Testing/TransactionProcessorACL.Testing.csproj
+++ b/TransactionProcessorACL.Testing/TransactionProcessorACL.Testing.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-	  <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build354" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build354" />
+    <PackageReference Include="ClientProxyBase" />
+      <PackageReference Include="TransactionProcessor.Client" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TransactionProcessorACL.Tests/TransactionProcessorACL.Tests.csproj
+++ b/TransactionProcessorACL.Tests/TransactionProcessorACL.Tests.csproj
@@ -7,20 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="TransactionProcessor.Client" Version="2026.4.3-build354" />
-    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" Version="2026.4.3-build354" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="TransactionProcessor.Client" />
+    <PackageReference Include="TransactionProcessor.IntegrationTesting.Helpers" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TransactionProcessorACL.sln
+++ b/TransactionProcessorACL.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\pullrequest.yml = .github\workflows\pullrequest.yml
 		.github\workflows\pushtomaster.yml = .github\workflows\pushtomaster.yml
 		.github\workflows\release-management.yml = .github\workflows\release-management.yml
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Global

--- a/TransactionProcessorACL/Bootstrapper/MediatorRegistry.cs
+++ b/TransactionProcessorACL/Bootstrapper/MediatorRegistry.cs
@@ -25,20 +25,7 @@ namespace TransactionProcessorACL.Bootstrapper
         /// </summary>
         public MediatorRegistry()
         {
-            this.AddTransient<IMediator, Mediator>();
-            
-            this.AddSingleton<IRequestHandler<VersionCheckCommands.VersionCheckCommand, Result>, VersionCheckRequestHandler>();
-            
-            this.AddSingleton<IRequestHandler<TransactionCommands.ProcessLogonTransactionCommand, Result<ProcessLogonTransactionResponse>>, TransactionRequestHandler>();
-            this.AddSingleton<IRequestHandler<TransactionCommands.ProcessSaleTransactionCommand, Result<ProcessSaleTransactionResponse>>, TransactionRequestHandler>();
-            this.AddSingleton<IRequestHandler<TransactionCommands.ProcessReconciliationCommand, Result<ProcessReconciliationResponse>>, TransactionRequestHandler>();
-            
-            this.AddSingleton<IRequestHandler<VoucherQueries.GetVoucherQuery, Result<GetVoucherResponse>>, VoucherRequestHandler>();
-            this.AddSingleton<IRequestHandler<VoucherCommands.RedeemVoucherCommand, Result<RedeemVoucherResponse>>, VoucherRequestHandler>();
-
-            this.AddSingleton<IRequestHandler<MerchantQueries.GetMerchantContractsQuery, Result<List<ContractResponse>>>, MerchantRequestHandler>();
-            this.AddSingleton<IRequestHandler<MerchantQueries.GetMerchantQuery, Result<MerchantResponse>>, MerchantRequestHandler>();
-            this.AddSingleton<IRequestHandler<MerchantQueries.GetMerchantScheduleQuery, Result<MerchantScheduleResponse>>, MerchantRequestHandler>();
+            this.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(VersionCheckRequestHandler).Assembly));
         }
 
         #endregion

--- a/TransactionProcessorACL/Dockerfile
+++ b/TransactionProcessorACL/Dockerfile
@@ -8,6 +8,8 @@ COPY ["TransactionProcessorACL/TransactionProcessorACL.csproj", "TransactionProc
 COPY ["TransactionProcessorACL.DataTransferObjects/TransactionProcessorACL.DataTransferObjects.csproj", "TransactionProcessorACL.DataTransferObjects/"]
 COPY ["TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj", "TransactionProcessorACL.BusinessLogic/"]
 COPY ["TransactionProcessorACL.Models/TransactionProcessorACL.Models.csproj", "TransactionProcessorACL.Models/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "TransactionProcessorACL/TransactionProcessorACL.csproj"
 COPY . .
 WORKDIR "/src/TransactionProcessorACL"

--- a/TransactionProcessorACL/Dockerfilewindows
+++ b/TransactionProcessorACL/Dockerfilewindows
@@ -9,6 +9,8 @@ COPY ["TransactionProcessorACL/TransactionProcessorACL.csproj", "TransactionProc
 COPY ["TransactionProcessorACL.DataTransferObjects/TransactionProcessorACL.DataTransferObjects.csproj", "TransactionProcessorACL.DataTransferObjects/"]
 COPY ["TransactionProcessorACL.BusinessLogic/TransactionProcessorACL.BusinessLogic.csproj", "TransactionProcessorACL.BusinessLogic/"]
 COPY ["TransactionProcessorACL.Models/TransactionProcessorACL.Models.csproj", "TransactionProcessorACL.Models/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "TransactionProcessorACL/TransactionProcessorACL.csproj"
 COPY . .
 WORKDIR "/src/TransactionProcessorACL"

--- a/TransactionProcessorACL/TransactionProcessorACL.csproj
+++ b/TransactionProcessorACL/TransactionProcessorACL.csproj
@@ -11,32 +11,32 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.4.0" />
-	  <PackageReference Include="OpenIddict.Validation.SystemNetHttp" Version="7.4.0" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.5.6" />
-	  <PackageReference Include="Lamar" Version="15.0.1" />
-	  <PackageReference Include="MediatR" Version="14.0.0" />
-	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-	  <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" />
+      <PackageReference Include="OpenIddict.Validation.SystemNetHttp" />
+      <PackageReference Include="ClientProxyBase" />
+      <PackageReference Include="Lamar" />
+      <PackageReference Include="MediatR" />
+      <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+      <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.Results.Web" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+      <PackageReference Include="Sentry.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Centralize NuGet package versions and refactor MediatR setup

Introduce Directory.Packages.props for centralized NuGet version management and update all projects to use it. Refactor MediatorRegistry to use AddMediatR with assembly scanning. Add Directory.Packages.props to the solution file.

closes #687
closes #688 