### PR TITLE
Add MerchantReportingId to MerchantResponse and tests

### DIFF
--- a/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACLApplicationServiceTests.cs
+++ b/TransactionProcessorACL.BusinessLogic.Tests/TransactionProcessorACLApplicationServiceTests.cs
@@ -495,6 +495,7 @@ namespace TransactionProcessorACL.BusinesssLogic.Tests
             merchantResponse.IsSuccess.ShouldBeTrue();
             merchantResponse.Data.ShouldNotBeNull();
             merchantResponse.Data.MerchantId.ShouldBe(TestData.MerchantId);
+            merchantResponse.Data.MerchantReportingId.ShouldBe(TestData.MerchantReportingId);
             merchantResponse.Data.Addresses.Count.ShouldBe(1);
             merchantResponse.Data.Addresses[0].AddressLine1.ShouldBe(TestData.AddressLine1);
             merchantResponse.Data.Addresses[0].Town.ShouldBe(TestData.Town);

--- a/TransactionProcessorACL.BusinessLogic/Services/ResponseFactory.cs
+++ b/TransactionProcessorACL.BusinessLogic/Services/ResponseFactory.cs
@@ -14,6 +14,7 @@ namespace TransactionProcessorACL.BusinessLogic.Services
         public static MerchantResponse Build(TransactionProcessor.DataTransferObjects.Responses.Merchant.MerchantResponse merchant) {
             MerchantResponse merchantResponse = new() {
                 MerchantId = merchant.MerchantId,
+                MerchantReportingId = merchant.MerchantReportingId,
                 EstateId = merchant.EstateId,
                 MerchantName = merchant.MerchantName,
                 EstateReportingId = merchant.EstateReportingId,

--- a/TransactionProcessorACL.IntegrationTests/Shared/ACLSteps.cs
+++ b/TransactionProcessorACL.IntegrationTests/Shared/ACLSteps.cs
@@ -188,6 +188,7 @@ public class ACLSteps{
         MerchantResponse merchantResponse = StringSerialiser.Deserialise<MerchantResponse>(responseContent, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
         merchantResponse.ShouldNotBeNull();
         merchantResponse.MerchantId.ShouldBe(merchantId);
+        merchantResponse.MerchantReportingId.ShouldNotBe(0);
         merchantResponse.MerchantName.ShouldBe(expectedMerchantResponse.MerchantName);
         merchantResponse.Addresses.ShouldNotBeNull();
         merchantResponse.Addresses.Count.ShouldBe(1);

--- a/TransactionProcessorACL.Testing/TestData.cs
+++ b/TransactionProcessorACL.Testing/TestData.cs
@@ -50,10 +50,9 @@ namespace TransactionProcessorACL.Testing
                                                                                           TransactionNumber = TestData.TransactionNumber
                                                                                       };
 
-        /// <summary>
-        /// The merchant identifier
-        /// </summary>
         public static Guid MerchantId = Guid.Parse("1C8354B7-B97A-46EA-9AD1-C43F33F7E3C3");
+
+        public static Int32 MerchantReportingId = 1;
 
         public static RequestAuditContext RequestAuditContext = new RequestAuditContext(
             RequestId: "req-123",
@@ -379,6 +378,7 @@ namespace TransactionProcessorACL.Testing
                 Contacts = new (){
                     Contact
                 },
+                MerchantReportingId = MerchantReportingId
             };
         public static List<TransactionProcessor.DataTransferObjects.Responses.Contract.ContractResponse> MerchantContractResponses(TransactionProcessor.DataTransferObjects.Responses.Contract.ProductType productType) =>
             new() {


### PR DESCRIPTION
Included MerchantReportingId in MerchantResponse construction and updated related tests to validate its presence and value. Updated test data to provide MerchantReportingId for consistency.

closes #706 