### PR TITLE
Fix typo in daily merchant performance summary endpoint

### DIFF
--- a/TransactionProcessorACL.IntegrationTests/Shared/ACLSteps.cs
+++ b/TransactionProcessorACL.IntegrationTests/Shared/ACLSteps.cs
@@ -248,7 +248,7 @@ public class ACLSteps{
         Guid merchantId = es1.EstateDetails.GetMerchantId(merchantName);
         Int32 merchantReportingId = es1.GetMerchantReportingId(merchantId);
 
-        String uri = "api/reporting/dailymerchantprformancesummary";
+        String uri = "api/reporting/dailymerchantperformancesummary";
         String userAccessToken = es1.GetMerchantUserToken(merchantId);
 
         this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", userAccessToken);

--- a/TransactionProcessorACL/Endpoints/ReportingEndpoints.cs
+++ b/TransactionProcessorACL/Endpoints/ReportingEndpoints.cs
@@ -13,8 +13,8 @@ public static class ReportingEndpoints
     {
         var group = app.MapGroup(BaseRoute).RequireAuthorization().RequireAuthorization(AuthorizationExtensions.PolicyNames.PasswordTokenOnlyPolicy);
 
-        // POST /api/reporting/dailymerchantprformancesummary
-        group.MapPost("dailymerchantprformancesummary", ReportingHandlers.GetMerchantDailyPerformanceSummary);
+        // POST /api/reporting/dailymerchantperformancesummary
+        group.MapPost("dailymerchantperformancesummary", ReportingHandlers.GetMerchantDailyPerformanceSummary);
         // POST /api/reporting/transactionmixsummary
         group.MapPost("transactionmixsummary", ReportingHandlers.GetMerchantTransactionMixSummary);
         // POST /api/reporting/recentactivityreceiptsearch


### PR DESCRIPTION
Corrected the route name from "dailymerchantprformancesummary" to "dailymerchantperformancesummary" in ReportingEndpoints to ensure accurate endpoint mapping.

closes #702 